### PR TITLE
turn react into peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/bigdatr/react-bouncefix/issues"
   },
   "homepage": "https://github.com/bigdatr/react-bouncefix",
-  "dependencies": {
-    "react": "^0.12.2"
+  "peerDependencies": {
+    "react": ">=0.12.2"
   }
 }


### PR DESCRIPTION
Hi, after the PR I submitted yesterday my app still keeps crashing with 0.13. I think the reason is that react is marked as a dependency, resulting in multiple runtime react instances (and possibly versions). Marking it as peer dependency should solve this (and is also more in line with how other react libraries handle the issue)
