### PR TITLE
replace React.__spread with Object.assign for React v15.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/bigdatr/react-bouncefix/issues"
   },
   "homepage": "https://github.com/bigdatr/react-bouncefix",
+  "devDependencies": {
+    "object-assign": "^4.0.1"
+  },
   "peerDependencies": {
     "react": ">=0.12.2"
   }

--- a/src/Bouncefix.js
+++ b/src/Bouncefix.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var assign = require('object-assign');
 
 var Bouncefix = React.createClass({
     displayName: 'Bouncefix',
@@ -48,7 +49,7 @@ var Bouncefix = React.createClass({
         this._blockTouchMove = false;
     },
     render: function() {
-      return React.createElement(this.props.componentClass, Object.assign({}, this.props, {
+      return React.createElement(this.props.componentClass, assign({}, this.props, {
             onTouchStart: this.onTouchStart,
             onTouchMove: this.onTouchMove,
             onTouchEnd: this.onTouchEnd,

--- a/src/Bouncefix.js
+++ b/src/Bouncefix.js
@@ -47,7 +47,7 @@ var Bouncefix = React.createClass({
         this._blockTouchMove = false;
     },
     render: function() {
-      return React.createElement(this.props.componentClass, React.__spread({}, this.props, {
+      return React.createElement(this.props.componentClass, Object.assign({}, this.props, {
             onTouchStart: this.onTouchStart,
             onTouchMove: this.onTouchMove,
             onTouchEnd: this.onTouchEnd,

--- a/src/Bouncefix.js
+++ b/src/Bouncefix.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 var Bouncefix = React.createClass({
     displayName: 'Bouncefix',
@@ -24,7 +25,7 @@ var Bouncefix = React.createClass({
         }
     },
     onTouchStart: function(e) {
-        var el = this.getDOMNode();
+        var el = ReactDOM.findDOMNode(this);
         var isScrollable = el.scrollHeight > el.offsetHeight;
 
         // If scrollable, adjust


### PR DESCRIPTION
Prior to React 15, React had a method called __spread which was really just Object.assign. This pr swaps out React.__spread for Object.assign.
