### PR TITLE
Fixing compatibility with newer versions of React

### DIFF
--- a/src/Bouncefix.js
+++ b/src/Bouncefix.js
@@ -49,12 +49,15 @@ var Bouncefix = React.createClass({
         this._blockTouchMove = false;
     },
     render: function() {
-      return React.createElement(this.props.componentClass, assign({}, this.props, {
-            onTouchStart: this.onTouchStart,
-            onTouchMove: this.onTouchMove,
-            onTouchEnd: this.onTouchEnd,
-            onTouchCancel: this.onTouchEnd
-      }), this.props.children);
+      var props = assign({}, this.props, {
+        onTouchStart: this.onTouchStart,
+        onTouchMove: this.onTouchMove,
+        onTouchEnd: this.onTouchEnd,
+        onTouchCancel: this.onTouchEnd
+      });
+      delete props.componentClass;
+      
+      return React.createElement(this.props.componentClass, props, this.props.children);
     }
 });
 


### PR DESCRIPTION
As per this change: https://facebook.github.io/react/warnings/unknown-prop.html Blindly passing props through is no longer supported.

Please update the npm package as soon as possible. Thanks!
