### PR TITLE
support changes in react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "react": ">=0.12.2"
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0",
+    "create-react-class": ">=15.0.0",
+    "prop-types": ">=15.0.0"
   }
 }

--- a/src/Bouncefix.js
+++ b/src/Bouncefix.js
@@ -1,11 +1,13 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var PropTypes = require('prop-types');
+var createClass = require('create-react-class');
 var assign = require('object-assign');
 
-var Bouncefix = React.createClass({
+var Bouncefix = createClass({
     displayName: 'Bouncefix',
     propTypes: {
-        componentClass: React.PropTypes.node
+        componentClass: PropTypes.node
     },
     getDefaultProps: function() {
         return {


### PR DESCRIPTION
leverages `prop-types` and `create-react-class` packages which were removed from core react